### PR TITLE
look for config from project root as well

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,18 @@ function getConfig ({
     findConfig = false
 }) {
     // Get webpack config
-    const resolvedConfigPath = findConfig ? findUp.sync(configPath) : resolve(process.cwd(), configPath);
+    let resolvedConfigPath = null;
+    if (findConfig) {
+        // Try to find a relative copy first
+        resolvedConfigPath = findUp.sync(configPath);
+
+        // Otherwise try relative to project root
+        if (resolvedConfigPath === null) {
+            resolvedConfigPath = resolve(dirname(findUp.sync('package.json')), configPath);
+        }
+    } else {
+        resolvedConfigPath = resolve(process.cwd(), configPath);
+    }
 
     let requiredConfig = require(resolvedConfigPath);
     if (requiredConfig && requiredConfig.__esModule && requiredConfig.default) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -67,3 +67,10 @@ test('throw an exception when we cant find the config', t => {
         findConfig: true
     }));
 });
+
+test('using config path from project root', t => {
+    t.notThrows(() => transformFile('fixtures/basic.absolute.js', {
+        config: "test/runtime.webpack.config.js",
+        findConfig: true
+    }));
+});


### PR DESCRIPTION
I encountered this error quite a bit with ava trying to use babel in the test file directory. This adds a fallback to search for the config file relative to the project's root directory. 
